### PR TITLE
Refine build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,28 +6,10 @@ Simple Flutter module to display the Fuchsia build status. This can be built bot
 
 1. ```cd $SRC/apps```
 2. ```git clone git@github.com:gregsimon/fuchsia_build_status.git dashboard```
-3. ```cp $SRC/apps/dashboard/misc_build_files/dashboard $SRC/packages/gn/```
-4. Modify ```$SRC/packages/gn/modules``` adding ```"dashboard"``` to the "imports" section:
-
-```
-
-    "labels": [
-        "//apps/modules"
-    ],
-    "imports": [
-      "chat",
-      "contacts",
-      "calendar",
-      "dashboard",
-      "email"
-    ],
-    "binaries": [
-        { ...
-```
-
-5. Build Fuchsia.
-6. Run Fuchsia.
-7. On the Fuchsia console:
+3. ```$SRC/packages/gn/gen.py -m default,../../apps/dashboard/misc_build_files/dashboard```
+4. ```$SRC/packages/gn/build.py```
+5. Run Fuchsia.
+6. On the Fuchsia console:
 ```device_runner --user_shell=dev_user_shell --user_shell_args=--root_module=dashboard```
 
 


### PR DESCRIPTION
Our package system can process files in different locations, there's no need to copy the file or modify existing package configurations.